### PR TITLE
fix safety net tests

### DIFF
--- a/packages/safety-net/jestconfig.json
+++ b/packages/safety-net/jestconfig.json
@@ -1,0 +1,6 @@
+{
+  "preset": "ts-jest",
+  "moduleFileExtensions": ["ts", "js"],
+  "testRegex": "(/__tests__/.*|(\\.|/)test)\\.ts$",
+  "moduleDirectories": ["<rootDir>", "node_modules"]
+}

--- a/packages/safety-net/jestconfig.json
+++ b/packages/safety-net/jestconfig.json
@@ -2,5 +2,6 @@
   "preset": "ts-jest",
   "moduleFileExtensions": ["ts", "js"],
   "testRegex": "(/__tests__/.*|(\\.|/)test)\\.ts$",
-  "moduleDirectories": ["<rootDir>", "node_modules"]
+  "moduleDirectories": ["<rootDir>", "node_modules"],
+  "testEnvironment": "jsdom"
 }

--- a/packages/safety-net/package.json
+++ b/packages/safety-net/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "test": "jest --config jest.config.ts",
+    "test": "jest --config jestconfig.json",
     "build": "tsc",
     "clean": "rm -rf lib"
   },


### PR DESCRIPTION
changed test script back to jestconfig.json for now. This is to get us unblocked, so we can publish. We can go back and fix it later.