### PR TITLE
SAF-5544: Superadmins and Admins can view roles

### DIFF
--- a/packages/safety-suite-api/src/api/permission/grants.ts
+++ b/packages/safety-suite-api/src/api/permission/grants.ts
@@ -2,7 +2,7 @@ import {Request} from '@idelic/safety-net';
 
 import {runApi} from '../../runApi';
 import {ApiOptions, ApiResponse, CustomerSpecificQuery, Id} from '../../types';
-import {DeleteResponse, Grant, GrantDTO, InputGrant} from './types';
+import {DeleteResponse, GrantDTO, InputGrant} from './types';
 
 /**
  * Gets a specific `Grant`
@@ -15,7 +15,7 @@ export const getGrant = (
   userId: Id,
   query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Grant>> =>
+): Request<ApiResponse<GrantDTO>> =>
   runApi({
     method: 'GET',
     urlRoot: 'permissionUrlRoot',
@@ -37,7 +37,7 @@ export const createGrant = (
   inputGrant: InputGrant,
   query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Grant>> =>
+): Request<ApiResponse<GrantDTO>> =>
   runApi({
     method: 'POST',
     urlRoot: 'permissionUrlRoot',
@@ -60,7 +60,7 @@ export const bulkCreateGrant = (
   inputGrants: InputGrant[],
   query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Grant[]>> =>
+): Request<ApiResponse<GrantDTO[]>> =>
   runApi({
     method: 'POST',
     urlRoot: 'permissionUrlRoot',
@@ -83,7 +83,7 @@ export const updateGrant = (
   grant: GrantDTO,
   query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Grant>> =>
+): Request<ApiResponse<GrantDTO>> =>
   runApi({
     method: 'PUT',
     urlRoot: 'permissionUrlRoot',
@@ -106,7 +106,7 @@ export const bulkUpdateGrant = (
   grants: InputGrant[],
   query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Grant[]>> =>
+): Request<ApiResponse<GrantDTO[]>> =>
   runApi({
     method: 'PUT',
     urlRoot: 'permissionUrlRoot',

--- a/packages/safety-suite-api/src/api/permission/grants.ts
+++ b/packages/safety-suite-api/src/api/permission/grants.ts
@@ -1,0 +1,141 @@
+import {Request} from '@idelic/safety-net';
+
+import {runApi} from '../../runApi';
+import {ApiOptions, ApiResponse, CustomerSpecificQuery, Id} from '../../types';
+import {DeleteResponse, Grant, GrantDTO, InputGrant} from './types';
+
+/**
+ * Gets a specific `Grant`
+ * @param userId ID of the `User` related to the grant.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns A single `Grant` object.
+ */
+export const getGrant = (
+  userId: Id,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Grant>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: `/api/grants/${userId}`,
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });
+
+/**
+ * Creates a new `Grant`
+ * @param inputGrant An `InputGrant` object.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns The created `Grant` object.
+ */
+export const createGrant = (
+  inputGrant: InputGrant,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Grant>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/grants',
+    apiOptions,
+    requestOptions: {
+      body: inputGrant,
+      query
+    }
+  });
+
+/**
+ * Create multiple `Grant`s simultaneously.
+ * @param inputGrants An array of `InputGrant` objects.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns An array of the created `Grant` objects.
+ */
+export const bulkCreateGrant = (
+  inputGrants: InputGrant[],
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Grant[]>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/grants/bulk',
+    apiOptions,
+    requestOptions: {
+      body: inputGrants,
+      query
+    }
+  });
+
+/**
+ * Update a specific `Grant`
+ * @param grant A `GrantDTO` object to update.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns An updated `Grant` object.
+ */
+export const updateGrant = (
+  grant: GrantDTO,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Grant>> =>
+  runApi({
+    method: 'PUT',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/grants',
+    apiOptions,
+    requestOptions: {
+      body: grant,
+      query
+    }
+  });
+
+/**
+ * Update multiple `Grant`s simultaneously.
+ * @param grants An array of `InputGrant` objects.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns An array of the updated `Grant` objects.
+ */
+export const bulkUpdateGrant = (
+  grants: InputGrant[],
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Grant[]>> =>
+  runApi({
+    method: 'PUT',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/grants/bulk',
+    apiOptions,
+    requestOptions: {
+      body: grants,
+      query
+    }
+  });
+
+/**
+ * Delete a specific grant by id.
+ * @param id Id of `Grant` to delete.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns An object containing the ID of the deleted `Grant` object.
+ */
+export const deleteGrant = (
+  id: Id,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<DeleteResponse>> =>
+  runApi({
+    method: 'DELETE',
+    urlRoot: 'permissionUrlRoot',
+    route: `/api/grants/${id}`,
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });

--- a/packages/safety-suite-api/src/api/permission/index.ts
+++ b/packages/safety-suite-api/src/api/permission/index.ts
@@ -1,0 +1,5 @@
+export * from './grants';
+export * from './roles';
+export * from './types';
+export * from './userPermission';
+export * from './modules';

--- a/packages/safety-suite-api/src/api/permission/modules.ts
+++ b/packages/safety-suite-api/src/api/permission/modules.ts
@@ -1,0 +1,35 @@
+import {Request} from '@idelic/safety-net';
+
+import {runApi} from '../../runApi';
+import {ApiOptions, ApiResponse} from '../../types';
+import {Module, ModulePermission} from './types';
+
+/**
+ * Gets all `Module`s
+ * @param apiOptions Optional options for runApi.
+ * @returns Array of `Module` objects.
+ */
+export const getModules = (
+  apiOptions: ApiOptions = {}
+): Request<ApiResponse<Module[]>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/modules',
+    apiOptions
+  });
+
+/**
+ * Gets array of all `ModulePermission`s.
+ * @param apiOptions Optional options for runApi.
+ * @returns Array of `ModulePermission` objects.
+ */
+export const getModulePermissions = (
+  apiOptions: ApiOptions = {}
+): Request<ApiResponse<ModulePermission[]>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/modules/permissions',
+    apiOptions
+  });

--- a/packages/safety-suite-api/src/api/permission/roles.ts
+++ b/packages/safety-suite-api/src/api/permission/roles.ts
@@ -1,0 +1,120 @@
+import {Request} from '@idelic/safety-net';
+
+import {runApi} from '../../runApi';
+import {ApiOptions, ApiResponse, CustomerSpecificQuery, Id} from '../../types';
+import {DeleteResponse, InputRole, Role} from './types';
+
+export interface GetRolesQuery extends CustomerSpecificQuery {
+  /**
+   * Defines whether the response should include
+   * `createdByUserName` and `lastUpdatedByUserName` or not.
+   */
+  includeUserNames?: boolean;
+}
+
+/**
+ * Gets a list of all available roles for a specific customer.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns Array of `Role` objects.
+ */
+export const getRoles = (
+  query: GetRolesQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Role[]>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/roles',
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });
+
+/**
+ * Updates a role.
+ * @param role `Role` object to update.
+ * @param apiOptions Optional options for runApi.
+ * @returns The updated `Role` object.
+ */
+export const updateRole = (
+  role: Role,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Role>> =>
+  runApi({
+    method: 'PUT',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/roles',
+    apiOptions,
+    requestOptions: {
+      body: role
+    }
+  });
+
+/**
+ * Creates a new role.
+ * @param inputRole `InputRole` object.
+ * @param role `Role` object to update.
+ * @param apiOptions Optional options for runApi.
+ * @returns The created `Role` object.
+ */
+export const createRole = (
+  inputRole: InputRole,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Role>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/roles',
+    apiOptions,
+    requestOptions: {
+      body: inputRole,
+      query
+    }
+  });
+
+/**
+ * Get a specific role by id.
+ * @param id Id of `Role` to get.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns A single `Role` object.
+ */
+export const getRole = (
+  id: Id,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<Role>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: `/api/roles/${id}`,
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });
+
+/**
+ * Delete a specific role by id.
+ * @param id Id of `Role` to delete.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns An object containing the ID of the deleted `Role` object.
+ */
+export const deleteRole = (
+  id: Id,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<DeleteResponse>> =>
+  runApi({
+    method: 'DELETE',
+    urlRoot: 'permissionUrlRoot',
+    route: `/api/roles/${id}`,
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });

--- a/packages/safety-suite-api/src/api/permission/roles.ts
+++ b/packages/safety-suite-api/src/api/permission/roles.ts
@@ -10,6 +10,10 @@ export interface GetRolesQuery extends CustomerSpecificQuery {
    * `createdByUserName` and `lastUpdatedByUserName` or not.
    */
   includeUserNames?: boolean;
+  /**
+   * Defines whether the response should include `usersCount` or not.
+   */
+  includeUsersCount?: boolean;
 }
 
 /**

--- a/packages/safety-suite-api/src/api/permission/types.ts
+++ b/packages/safety-suite-api/src/api/permission/types.ts
@@ -6,9 +6,9 @@ export interface Created extends CreatedBy {
    */
   createdByName?: string;
   /**
-   * Unix timestamp of role creation.
+   * ISO timestamp of role creation.
    */
-  createdDate: number;
+  createdDate: string;
 }
 
 export interface LastUpdated extends LastUpdatedBy {
@@ -17,9 +17,9 @@ export interface LastUpdated extends LastUpdatedBy {
    */
   lastUpdatedByName?: string;
   /**
-   * Unix timestamp of the last time when this role was updated.
+   * ISO timestamp of the last time when this role was updated.
    */
-  lastUpdatedDate: number;
+  lastUpdatedDate: string;
 }
 
 export enum RoleType {
@@ -65,6 +65,10 @@ export interface Role extends Created, LastUpdated {
    * Array of module permission ids granted to this role.
    */
   modulePermissions: Id[];
+  /**
+   * The count of users assigned to this role.
+   */
+  usersCount?: number;
 }
 
 export type InputRole = Pick<

--- a/packages/safety-suite-api/src/api/permission/types.ts
+++ b/packages/safety-suite-api/src/api/permission/types.ts
@@ -1,0 +1,180 @@
+import {Alias, CreatedBy, Id, LastUpdatedBy} from '../../types';
+
+export interface Created extends CreatedBy {
+  /**
+   * Full name of the user who has created this role.
+   */
+  createdByName?: string;
+  /**
+   * Unix timestamp of role creation.
+   */
+  createdDate: number;
+}
+
+export interface LastUpdated extends LastUpdatedBy {
+  /**
+   * Full name of the user who was the last to update this role.
+   */
+  lastUpdatedByName?: string;
+  /**
+   * Unix timestamp of the last time when this role was updated.
+   */
+  lastUpdatedDate: number;
+}
+
+export enum RoleType {
+  superAdmin = 'SUPERADMIN',
+  admin = 'ADMIN',
+  user = 'USER'
+}
+
+export interface Role extends Created, LastUpdated {
+  /**
+   * The unique Role ID.
+   */
+  id: Id;
+  /**
+   * Role alias.
+   */
+  alias: Alias;
+  /**
+   * Role name.
+   */
+  name: string;
+  /**
+   * Role description.
+   */
+  description: string;
+  /**
+   * Role type.
+   */
+  roleType: RoleType;
+  /**
+   * Customer alias.
+   */
+  customerAlias: string;
+  /**
+   * true if this role can be edited, false otherwise.
+   */
+  editable: boolean;
+  /**
+   * true if this role can be deleted, false otherwise.
+   */
+  deletable: boolean;
+  /**
+   * Array of module permission ids granted to this role.
+   */
+  modulePermissions: Id[];
+}
+
+export type InputRole = Pick<
+  Role,
+  'name' | 'description' | 'modulePermissions'
+>;
+
+export interface Grant {
+  /**
+   * The unique Grant ID.
+   */
+  id: number;
+  /**
+   * The related User ID.
+   */
+  userId: number;
+  /**
+   * The related Role ID.
+   */
+  roleId: number;
+  /**
+   * Array of group IDs.
+   */
+  groupIds: number[];
+  /**
+   * The ID of the User which created this grant.
+   */
+  grantedBy: number;
+  /**
+   * The unix timestamp when this grant was created.
+   */
+  grantedDate: number;
+  /**
+   * The ID of the User which last updated this grant.
+   */
+  lastUpdatedBy: number;
+  /**
+   * The unix timestamp when this grant was last updated.
+   */
+  lastUpdatedDate: number;
+  /**
+   * The alias of the customer which this grant is for.
+   */
+  customerAlias: string;
+}
+
+export type InputGrant = Pick<Grant, 'userId' | 'roleId' | 'groupIds'>;
+
+export type GrantDTO = Pick<
+  Grant,
+  'id' | 'userId' | 'roleId' | 'groupIds' | 'customerAlias'
+>;
+
+export interface UserPermissions {
+  /**
+   * If the user has the `superAdmin` role.
+   */
+  superAdmin: boolean;
+  /**
+   * If the user has the `admin` role.
+   */
+  admin: boolean;
+  /**
+   * If the user is not an admin, this will contain a key value map where the key is a module name
+   * and the value is another map with a permission name key and a list of id as the value.
+   */
+  permissions: Record<string, Record<string, number[]>>;
+}
+
+export interface Module {
+  /**
+   * The unique Module ID.
+   */
+  id: Id;
+  /**
+   * Module alias.
+   */
+  alias: Alias;
+  /**
+   * Module name.
+   */
+  name: string;
+  /**
+   * Module description.
+   */
+  description: string;
+}
+
+export interface ModulePermission {
+  /**
+   * The unique ModulePermission ID.
+   */
+  id: Id;
+  /**
+   * ModulePermission alias.
+   */
+  alias: Alias;
+  /**
+   * ModulePermission name.
+   */
+  name: string;
+  /**
+   * The related Module ID.
+   */
+  moduleId: Id;
+}
+
+export interface DeleteResponse {
+  /**
+   * Id of the record which was successfully deleted.
+   */
+  id: Id;
+}

--- a/packages/safety-suite-api/src/api/permission/userPermission.ts
+++ b/packages/safety-suite-api/src/api/permission/userPermission.ts
@@ -1,0 +1,25 @@
+import {Request} from '@idelic/safety-net';
+
+import {runApi} from '../../runApi';
+import {ApiOptions, ApiResponse, CustomerSpecificQuery} from '../../types';
+import {UserPermissions} from './types';
+
+/**
+ * Gets `UserPermissions` object for the current user.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns `UserPermissions` object.
+ */
+export const getCurrentUserPermissions = (
+  query: CustomerSpecificQuery,
+  apiOptions: ApiOptions = {}
+): Request<ApiResponse<UserPermissions>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'permissionUrlRoot',
+    route: '/api/permissions/user/current',
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });

--- a/packages/safety-suite-api/src/api/userManagement/index.ts
+++ b/packages/safety-suite-api/src/api/userManagement/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './users';

--- a/packages/safety-suite-api/src/api/userManagement/types.ts
+++ b/packages/safety-suite-api/src/api/userManagement/types.ts
@@ -1,0 +1,28 @@
+import {Id} from '../../types';
+
+export interface User {
+  /**
+   * The unique User ID.
+   */
+  id: Id;
+  /**
+   * User's email.
+   */
+  email: string;
+  /**
+   * User's first name.
+   */
+  firstName: string;
+  /**
+   * User's last name.
+   */
+  lastName: string;
+  /**
+   * Flag which determines whether User is registered.
+   */
+  registered: boolean;
+  /**
+   * Flag which determines whether User is active.
+   */
+  active: boolean;
+}

--- a/packages/safety-suite-api/src/api/userManagement/types.ts
+++ b/packages/safety-suite-api/src/api/userManagement/types.ts
@@ -26,3 +26,16 @@ export interface User {
    */
   active: boolean;
 }
+
+export interface UserWithRoleNames {
+  /**
+   * `User` object.
+   */
+  user: User;
+  /**
+   * Array of `Role` names which are granted to the included `User`
+   */
+  roleNames: string[];
+}
+
+export type InputUser = Pick<User, 'email' | 'firstName' | 'lastName'>;

--- a/packages/safety-suite-api/src/api/userManagement/users.ts
+++ b/packages/safety-suite-api/src/api/userManagement/users.ts
@@ -1,0 +1,74 @@
+import {Request} from '@idelic/safety-net';
+
+import {runApi} from '../../runApi';
+import {ApiOptions, ApiResponse, CustomerSpecificQuery, Id} from '../../types';
+import {User} from './types';
+
+export interface GetUsersQuery extends Partial<CustomerSpecificQuery> {
+  /**
+   * Filter users by these ids.
+   */
+  ids?: Id[];
+}
+
+/**
+ * Get a list of users.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns Array of `User` objects.
+ */
+export const getUsers = (
+  query: GetUsersQuery = {},
+  apiOptions?: ApiOptions
+): Request<ApiResponse<User[]>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'userManagementUrlRoot',
+    route: '/api/users',
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });
+
+/**
+ * Get a specific user by id.
+ * @param id Get user by this id.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns A single `User` object.
+ */
+export const getUser = (
+  id: Id,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<User>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'userManagementUrlRoot',
+    route: `/api/users/${id}`,
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });
+
+/**
+ * Get the current logged in user.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns The `User` object of the currently logged in user.
+ */
+export const getCurrentUser = (
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<User>> =>
+  runApi({
+    method: 'GET',
+    urlRoot: 'userManagementUrlRoot',
+    route: '/api/users/current',
+    apiOptions,
+    requestOptions: {
+      query
+    }
+  });

--- a/packages/safety-suite-api/src/api/userManagement/users.ts
+++ b/packages/safety-suite-api/src/api/userManagement/users.ts
@@ -1,15 +1,8 @@
 import {Request} from '@idelic/safety-net';
 
 import {runApi} from '../../runApi';
-import {ApiOptions, ApiResponse, CustomerSpecificQuery, Id} from '../../types';
-import {User} from './types';
-
-export interface GetUsersQuery extends Partial<CustomerSpecificQuery> {
-  /**
-   * Filter users by these ids.
-   */
-  ids?: Id[];
-}
+import {ApiOptions, ApiResponse, CustomerSpecificQuery} from '../../types';
+import {InputUser, User, UserWithRoleNames} from './types';
 
 /**
  * Get a list of users.
@@ -18,35 +11,13 @@ export interface GetUsersQuery extends Partial<CustomerSpecificQuery> {
  * @returns Array of `User` objects.
  */
 export const getUsers = (
-  query: GetUsersQuery = {},
+  query: CustomerSpecificQuery,
   apiOptions?: ApiOptions
-): Request<ApiResponse<User[]>> =>
+): Request<ApiResponse<UserWithRoleNames[]>> =>
   runApi({
     method: 'GET',
     urlRoot: 'userManagementUrlRoot',
     route: '/api/users',
-    apiOptions,
-    requestOptions: {
-      query
-    }
-  });
-
-/**
- * Get a specific user by id.
- * @param id Get user by this id.
- * @param query Object containing query params for this route.
- * @param apiOptions Optional options for runApi.
- * @returns A single `User` object.
- */
-export const getUser = (
-  id: Id,
-  query: CustomerSpecificQuery,
-  apiOptions?: ApiOptions
-): Request<ApiResponse<User>> =>
-  runApi({
-    method: 'GET',
-    urlRoot: 'userManagementUrlRoot',
-    route: `/api/users/${id}`,
     apiOptions,
     requestOptions: {
       query
@@ -71,4 +42,65 @@ export const getCurrentUser = (
     requestOptions: {
       query
     }
+  });
+
+/**
+ * Invite a new user.
+ * @param user `InputUser` object containing information about the user.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns The `User` object of the invited user.
+ */
+export const inviteUser = (
+  user: InputUser,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<User>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'userManagementUrlRoot',
+    route: '/api/users/invite',
+    apiOptions,
+    requestOptions: {
+      body: user,
+      query
+    }
+  });
+
+/**
+ * Resend an invite to a user.
+ * @param user `User` object of the user to which the invite will be resent.
+ * @param query Object containing query params for this route.
+ * @param apiOptions Optional options for runApi.
+ * @returns Auth0 response.
+ */
+export const resendUserInvite = (
+  user: User,
+  query: CustomerSpecificQuery,
+  apiOptions?: ApiOptions
+): Request<ApiResponse<string>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'userManagementUrlRoot',
+    route: '/api/users/resendInvite',
+    apiOptions,
+    requestOptions: {
+      body: user,
+      query
+    }
+  });
+
+/**
+ * Sends a change password request for the currently logged in user.
+ * @param apiOptions Optional options for runApi.
+ * @returns Auth0 response.
+ */
+export const changePassword = (
+  apiOptions?: ApiOptions
+): Request<ApiResponse<string>> =>
+  runApi({
+    method: 'POST',
+    urlRoot: 'userManagementUrlRoot',
+    route: '/api/users/changePassword',
+    apiOptions
   });

--- a/packages/safety-suite-api/src/config.ts
+++ b/packages/safety-suite-api/src/config.ts
@@ -16,14 +16,16 @@ export type InitConfig = Config & {
 };
 
 export const config: InitConfig = {
-  initialized: false,
   apiUrlRoot: '',
-  loginUrlRoot: '',
   configUrlRoot: '',
+  dashboardSinkUrlRoot: '',
   documentLibraryUrlRoot: '',
   eformsUrlRoot: '',
-  dashboardSinkUrlRoot: '',
-  onAuthError: () => {}
+  initialized: false,
+  loginUrlRoot: '',
+  onAuthError: () => {},
+  permissionUrlRoot: '',
+  userManagementUrlRoot: ''
 };
 
 export interface CrudOptions extends NestedConfiguration {
@@ -453,10 +455,12 @@ export const initializeConfig = (
     !matchesConfig(nestedConfig, {
       services: {
         app: {url: ''},
+        dashboardSink: {url: ''},
         documentLibrary: {url: ''},
         eforms: {url: ''},
+        permission: {url: ''},
         saf: {url: ''},
-        dashboardSink: {url: ''}
+        usermanagement: {url: ''}
       }
     })
   ) {
@@ -464,10 +468,12 @@ export const initializeConfig = (
   }
   config.configUrlRoot = configUrl;
   config.apiUrlRoot = nestedConfig.services.saf.url;
-  config.loginUrlRoot = nestedConfig.services.app.url;
+  config.dashboardSinkUrlRoot = nestedConfig.services.dashboardSink.url;
   config.documentLibraryUrlRoot = nestedConfig.services.documentLibrary.url;
   config.eformsUrlRoot = nestedConfig.services.eforms.url;
-  config.dashboardSinkUrlRoot = nestedConfig.services.dashboardSink.url;
+  config.loginUrlRoot = nestedConfig.services.app.url;
+  config.permissionUrlRoot = nestedConfig.services.permission.url;
+  config.userManagementUrlRoot = nestedConfig.services.usermanagement.url;
   config.initialized = true;
 };
 

--- a/packages/safety-suite-api/src/types.ts
+++ b/packages/safety-suite-api/src/types.ts
@@ -11,7 +11,9 @@ export type UrlRoot =
   | 'documentLibraryUrlRoot'
   | 'configUrlRoot'
   | 'eformsUrlRoot'
-  | 'dashboardSinkUrlRoot';
+  | 'dashboardSinkUrlRoot'
+  | 'permissionUrlRoot'
+  | 'userManagementUrlRoot';
 
 export interface Api<R, T> {
   method: Methods;
@@ -75,6 +77,15 @@ export interface ApiSuccessResponse<T> {
   _embedded?: T;
   page?: Page;
   _links?: Links;
+}
+
+export interface CustomerSpecificQuery {
+  /**
+   * Filter restricting the scope of the request to a single SAF
+   * instance at a time and allowing to check permissions of a user
+   * for a specific customer.
+   */
+  customerAlias: string;
 }
 
 export interface LastUpdatedBy {


### PR DESCRIPTION
https://idelic.atlassian.net/browse/SAF-5544

`permission` and `userManagement` modules aren't exported in the `src/api/index.ts` in order to avoid conflicts with duplicate type definitions. E.g. `User`

@kboriak @andrey-partola Might be useful to have some of the backend engineers validate that the JSDoc and typings look right here. Everything was copied from api-reference if possible, and the scala code as a fallback. Specifically the grant update routes don't look quite right with the types specified in the scala code, but there might be a reason for that.