### PR TITLE
SAF-6289: FE: KPI API request 'groupIds' field move to 'filter' field value

### DIFF
--- a/packages/safety-suite-api/src/api/dashboardSink/types.ts
+++ b/packages/safety-suite-api/src/api/dashboardSink/types.ts
@@ -47,7 +47,6 @@ export interface KpiRequestBody {
   aggregation: KpiAggregation;
   time?: KpiTime;
   normalization?: string;
-  groupIds?: number[];
   filter?: string;
   groups?: string[];
 }


### PR DESCRIPTION
This PR removes groupIds from the kpi request body.

https://idelic.atlassian.net/browse/SAF-6298