### PR TITLE
SAF-6990: Fix return types, formatting

### DIFF
--- a/packages/safety-suite-api/src/api/claims/balance.ts
+++ b/packages/safety-suite-api/src/api/claims/balance.ts
@@ -1,7 +1,7 @@
 import {Request} from '@idelic/safety-net';
+import {ApiOptions} from 'src/types';
 
 import {runApi} from '../../runApi';
-import {ApiOptions, ApiResponse} from '../../types';
 
 export interface Balance {
   category: string;
@@ -24,7 +24,7 @@ export function getBalanceByClaimId(
   claimId: string,
   customerAlias: string,
   apiOptions?: ApiOptions
-): Request<ApiResponse<Balance[]>> {
+): Request<Balance[]> {
   return runApi({
     method: 'GET',
     urlRoot: 'claimsSinkUrlRoot',

--- a/packages/safety-suite-api/src/api/claims/claims.ts
+++ b/packages/safety-suite-api/src/api/claims/claims.ts
@@ -1,10 +1,5 @@
 import {Request} from '@idelic/safety-net';
-import {
-  ApiOptions,
-  ApiResponse,
-  ApiSuccessResponse,
-  EmptyResponse
-} from 'src/types';
+import {ApiOptions, ApiSuccessResponse, EmptyResponse} from 'src/types';
 
 import {runApi} from '../../runApi';
 import {PageRequest} from '../pageRequest';
@@ -147,11 +142,11 @@ export function getClaims(
   pageRequest: PageRequest,
   customerAlias: string,
   apiOptions?: ApiOptions
-): Request<ApiResponse<ApiSuccessResponse<ClaimResponse>>> {
+): Request<ApiSuccessResponse<ClaimResponse>> {
   return runApi({
     method: 'POST',
     urlRoot: 'claimsSinkUrlRoot',
-    route: `/api/claims`,
+    route: '/api/claims',
     apiOptions,
     requestOptions: {
       query: {
@@ -174,7 +169,7 @@ export function getClaimById(
   claimId: string,
   customerAlias: string,
   apiOptions?: ApiOptions
-): Request<ApiResponse<ClaimModel>> {
+): Request<ClaimModel> {
   return runApi({
     method: 'GET',
     urlRoot: 'claimsSinkUrlRoot',
@@ -200,11 +195,11 @@ export function createClaim(
   inputClaim: ClaimModel,
   customerAlias: string,
   apiOptions?: ApiOptions
-): Request<ApiResponse<ClaimModel>> {
+): Request<ClaimModel> {
   return runApi({
     method: 'POST',
     urlRoot: 'claimsSourceUrlRoot',
-    route: `/api/claims`,
+    route: '/api/claims',
     apiOptions,
     requestOptions: {
       query: {
@@ -229,7 +224,7 @@ export function updateClaim(
   claimId: string,
   customerAlias: string,
   apiOptions?: ApiOptions
-): Request<ApiResponse<ClaimModel>> {
+): Request<ClaimModel> {
   return runApi({
     method: 'PUT',
     urlRoot: 'claimsSourceUrlRoot',


### PR DESCRIPTION
- removed ApiResponse type from claims and balance - old mistake
- intended version for publish:  44.1.2