### PR TITLE
SAF-7287: add parentId for Module type

### DIFF
--- a/packages/safety-suite-api/src/api/permission/types.ts
+++ b/packages/safety-suite-api/src/api/permission/types.ts
@@ -177,6 +177,10 @@ export interface Module {
    * Module description.
    */
   description: string;
+  /**
+   * The unique Module Parent ID.
+   */
+  parentId?: Id;
 }
 
 export interface ModulePermission {


### PR DESCRIPTION
Add `parentId `for Module type.

<img width="905" alt="Screenshot 2022-04-18 at 22 32 25" src="https://user-images.githubusercontent.com/91739319/163865536-3772d721-4d80-469f-9002-585baa543b6b.png">
