### PR TITLE
SAF-7287: add infoMessage for Module type

### DIFF
--- a/packages/safety-suite-api/src/api/permission/types.ts
+++ b/packages/safety-suite-api/src/api/permission/types.ts
@@ -181,6 +181,10 @@ export interface Module {
    * The unique Module Parent ID.
    */
   parentId?: Id;
+  /**
+   * Information message for tooltip
+   */
+  infoMessage?: string;
 }
 
 export interface ModulePermission {


### PR DESCRIPTION
Add `infoMessage` for Module type for using in tooltip.

<img width="911" alt="Screenshot 2022-04-20 at 13 41 00" src="https://user-images.githubusercontent.com/91739319/164213802-ce9821c2-631b-49f5-a756-682aa62daa91.png">
