### PR TITLE
SAF-7302: add sort order to roles

### DIFF
--- a/packages/safety-suite-api/src/api/permission/types.ts
+++ b/packages/safety-suite-api/src/api/permission/types.ts
@@ -69,6 +69,10 @@ export interface Role extends Created, LastUpdated {
    * The count of users assigned to this role.
    */
   usersCount?: number;
+  /**
+   * Sort order for roles
+   */
+  sortOrder?: number;
 }
 
 export type InputRole = Pick<


### PR DESCRIPTION
Add `sortOrder` to the Role interface.