### PR TITLE
SAF-7745:  Only Display Data Sets in Discover Dashboard that are Sync'ed (FE)

### DIFF
--- a/packages/safety-suite-api/src/api/dashboardSink/types.ts
+++ b/packages/safety-suite-api/src/api/dashboardSink/types.ts
@@ -198,6 +198,7 @@ export interface DatasetMeta {
   moduleAliases: string[];
   hasDefaultDate: boolean;
   attributes: AttributeMeta[];
+  isSynced: boolean;
 }
 
 export interface DatasetMetaResponse {


### PR DESCRIPTION
add isSynced to DatasetMeta

https://idelic.atlassian.net/browse/SAF-7745