### PR TITLE
SAF-7747: Allows saving of config values

### DIFF
--- a/packages/safety-suite-api/src/api/configService.ts
+++ b/packages/safety-suite-api/src/api/configService.ts
@@ -26,10 +26,10 @@ export function getConfigTypeNames(
   });
 }
 
-export type ConfigSpec = {
+export type ConfigSpec<Value = any> = {
   key: string;
   storageType: string;
-  value: string;
+  value: Value;
   valueType: string;
   valueOptions?: {
     itemValueType: string;
@@ -57,6 +57,23 @@ export function getConfigTypeWithName(
     method: 'GET',
     urlRoot: 'configServiceUrlRoot',
     route: `/api/configuration/${type}/${name}`,
+    apiOptions
+  });
+}
+
+export function updateConfigValue(
+  spec: ConfigSpec,
+  type: string,
+  name: string,
+  apiOptions?: ApiOptions
+): Request<ApiSuccessResponse<ConfigType>> {
+  return runApi({
+    method: 'PUT',
+    urlRoot: 'configServiceUrlRoot',
+    route: `/api/configuration/${type}/${name}`,
+    requestOptions: {
+      body: spec
+    },
     apiOptions
   });
 }


### PR DESCRIPTION
Developed to this spec: [`PUT /api/configuration/{type}/{name}`](https://api-reference.testing.idelic.software/service/config-service#put-/api/configuration/-type-/-name-)