### PR TITLE
Disallow `src` Imports

### DIFF
--- a/packages/safety-net/src/__tests__/index.test.ts
+++ b/packages/safety-net/src/__tests__/index.test.ts
@@ -1,6 +1,5 @@
-import createXhr from 'test/xhrMock';
-
 import net from '..';
+import createXhr from '../../test/xhrMock';
 
 jest.useFakeTimers();
 

--- a/packages/safety-net/tsconfig.json
+++ b/packages/safety-net/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,

--- a/packages/safety-suite-api/tsconfig.json
+++ b/packages/safety-suite-api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "baseUrl": ".",
     "target": "es5",
     "esModuleInterop": true,
     "module": "commonjs",
@@ -13,4 +12,3 @@
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]
 }
-


### PR DESCRIPTION
Previously we didn't have a way to detect or prevent non-relative imports in the code. This has caused a handful of issues in the past which this PR will prevent in the future.