### PR TITLE
SAF-9980: Display New Task Type Fields (FE)

### DIFF
--- a/packages/safety-suite-api/src/api/models/modelTypes.ts
+++ b/packages/safety-suite-api/src/api/models/modelTypes.ts
@@ -2694,6 +2694,7 @@ export interface ImprovementPlanTaskRelations {
   primaryModel: EmployeeModel;
   progressUpdate?: ImprovementPlanProgressUpdateModel | null;
   talkingPoints?: TalkingPointModel[];
+  trainingClass?: TrainingClassModel;
 }
 
 export interface ImprovementPlanTaskInputRelations {
@@ -2703,6 +2704,7 @@ export interface ImprovementPlanTaskInputRelations {
   primaryModel: EmployeeInputModel;
   progressUpdate?: ImprovementPlanProgressUpdateInputModel | null;
   talkingPoints?: TalkingPointInputModel[];
+  trainingClass?: TrainingClassModel;
 }
 
 export interface ImprovementPlanTaskComputations {
@@ -3898,12 +3900,14 @@ export interface TrainingClassRelations {
   attendees?: TrainingAttendanceModel[];
   trainer?: EmployeeModel | null;
   trainingCourse: TrainingCourseModel;
+  improvementPlanTask?: ImprovementPlanTaskModel;
 }
 
 export interface TrainingClassInputRelations {
   attendees?: TrainingAttendanceInputModel[];
   trainer?: EmployeeInputModel | null;
   trainingCourse: TrainingCourseInputModel;
+  improvementPlanTask?: ImprovementPlanTaskModel;
 }
 
 export interface TrainingClassComputations {

--- a/packages/safety-suite-api/src/api/models/modelTypes.ts
+++ b/packages/safety-suite-api/src/api/models/modelTypes.ts
@@ -2833,6 +2833,9 @@ export interface ImprovementPlanTaskTemplateFields {
   positionAssignedTo?: string | null;
   reminders?: string | null;
   type?: string | null;
+  isTrainingExpiring?: string | null;
+  trainingExpirationInterval?: number;
+  trainingExpirationIntervalUnits?: string | null;
 }
 
 export interface ImprovementPlanTaskTemplateRelations {
@@ -2840,6 +2843,7 @@ export interface ImprovementPlanTaskTemplateRelations {
   improvementPlan?: ImprovementPlanTemplateModel | null;
   improvementPlanWeek?: ImprovementPlanWeekTemplateModel | null;
   talkingPoints?: TalkingPointTemplateModel[];
+  trainingCourse?: TrainingCourseModel;
 }
 
 export interface ImprovementPlanTaskTemplateInputRelations {


### PR DESCRIPTION
This PR adds the new fields and relation to improvement plan task template that were adding in this [PR](https://github.com/idelic-inc/safety-suite/pull/3202/files).

https://idelic.atlassian.net/browse/SAF-9980